### PR TITLE
Update ProjectDriver.java

### DIFF
--- a/src/plptool/gui/ProjectDriver.java
+++ b/src/plptool/gui/ProjectDriver.java
@@ -192,10 +192,8 @@ public final class ProjectDriver
 	/**
 	 * The constructor for the project driver.
 	 *
-	 * @param g
+	 * @param modes
 	 *            Specifies whether we are driving a GUI or not
-	 * @param archID
-	 *            The ISA to use for this project
 	 */
 	public ProjectDriver(int modes)
 	{
@@ -299,8 +297,11 @@ public final class ProjectDriver
 		// check for JRE version
 		
 		String tokens[] = System.getProperty("java.version").split("\\.");
-		int major = Integer.parseInt(tokens[0]);
-		int minor = Integer.parseInt(tokens[1]);
+			int major = Integer.parseInt(tokens[0]);
+			int minor = 0; // Default value to prevent index OOB exception.
+		if (tokens.length >= 2) {
+			 minor = Integer.parseInt(tokens[1]);
+		}
 		
 		if ((major == Constants.minimumJREMajorVersion && minor < Constants.minimumJREMinorVersion)
 				|| major < Constants.minimumJREMajorVersion)
@@ -317,7 +318,7 @@ public final class ProjectDriver
 	/**
 	 * Set a new architecture for the project
 	 *
-	 * @param arch
+	 * @param archID
 	 * @return
 	 */
 	public int setArch(int archID)

--- a/src/plptool/gui/ProjectDriver.java
+++ b/src/plptool/gui/ProjectDriver.java
@@ -297,8 +297,8 @@ public final class ProjectDriver
 		// check for JRE version
 		
 		String tokens[] = System.getProperty("java.version").split("\\.");
-			int major = Integer.parseInt(tokens[0]);
-			int minor = 0; // Default value to prevent index OOB exception.
+		int major = Integer.parseInt(tokens[0]);
+		int minor = 0; // Default value for JVMs without minor versions.
 		if (tokens.length >= 2) {
 			 minor = Integer.parseInt(tokens[1]);
 		}


### PR DESCRIPTION
Problem:  IOOB exception on launch.
Platforms Affected: All
Java Version: 14(+?)

Root Cause: ProjectDriver expects a minor revision and creates an Index Out of Bounds exception when it attempts to access the index of a minor revision which does not exist.

Stack Trace:
=====================================
FATAL ERROR: Failed to initialize GUI
=====================================
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
	at plptool.gui.ProjectDriver.<init>(ProjectDriver.java:283)
	at plptool.gui.PLPToolApp.startup(PLPToolApp.java:99)
	at org.jdesktop.application.Application$1.run(Application.java:171)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:316)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:770)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:391)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:740)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
[DEBUG] Exit(-1)
[DEBUG] Shutdown hook

Fix:  Tested on MacOS Catalina 15.4, OpenJDK 14
* Added check for array length to prevent index out of bounds exception.
* Fixed invalid @param annotations.